### PR TITLE
Added travis pdf generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ dist: bionic
 
 install:
   - source ./texlive/texlive_install.sh
+  - pip install ghp-import --user
 
 cache:
   directories:
@@ -14,3 +15,16 @@ cache:
 script:
  - cd whitepaper
  - make latex
+
+deploy:
+  - provider: releases
+    skip_cleanup: true
+    file: ../_build/main.pdf
+    api_key: $GITHUB_TOKEN
+    on:
+      tags: true
+  - provider: script
+    skip_cleanup: true
+    script: make github
+    on:
+      branch: master

--- a/whitepaper/Makefile
+++ b/whitepaper/Makefile
@@ -37,3 +37,7 @@ latex:
 clean:
 	@rm -rf $(BUILDDIR)
 	@echo "Removed $(BUILDDIR) directory"
+
+github:
+	@ghp-import -n $(BUILDDIR)
+	@git push -fq https://${GITHUB_TOKEN}@github.com/$(REPO_SLUG).git gh-pages > /dev/null


### PR DESCRIPTION
- Every time there is a new commit into master, publishes the generated pdf to gh-pages.
- Every time a new tag is published attaches the generated pdf to it.

Have to add the variables GH_TOKEN and REPO_SLUG to Travis.