### PR TITLE
Unification

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,8 +7,8 @@ In math and text mode:
 In math mode:
  * Use `\mathfunc` to mark multi-letter functions, i.e. `\func{verify}(a, b, c)`
  * Use `\structField` to refer to cpp fields inside math mode, i.e. `\structField{X}{SomeField}`, right now, X should be single letter
- * Use `\mathit` to refer to multi-letter, but single word variables
- * Use `\textit` to refer to multi word variables
+ * Use `\mathvar` to refer to multi-letter, but single word variables
+ * Use `\mathname` to refer to multi word variables
 
 In text mode:
  * Use `\field` to refer to cpp field names.

--- a/whitepaper/chapters/accounts_img1.tex
+++ b/whitepaper/chapters/accounts_img1.tex
@@ -26,7 +26,7 @@
 	% third row - ripeMD
 
 	% it's easier to do it this way, as problems with paths show up when using nested tikzpicture
-	\node[below left=1.5cm and -2cm of bpk,anchor=center] (ripeInner) { $ripemd160(sha3\_256($ };
+	\node[below left=1.5cm and -2cm of bpk,anchor=center] (ripeInner) { $\mathfunc{ripemd160}(\mathfunc{sha3\_256}($ };
 	\node[right=of ripeInner, draw, dotted,rounded corners=0] (bpkInnerLabel) {compressed-public-key};
 	\node[right=of bpkInnerLabel] (ripeInner2) { $)) $ };
 
@@ -44,7 +44,7 @@
 	\draw[dotted] (ripe.south east) -- (brmd20.north east);
 
 	% Fifth row - SHA3(version + ripe)
-	\node[below right=2.5cm and -6cm of brmd20,anchor=center] (checkInner) { $sha3\_256($ };
+	\node[below right=2.5cm and -6cm of brmd20,anchor=center] (checkInner) { $\mathfunc{sha3\_256(}$ };
 	\node[crecb,right=of checkInner] (bInnerRmd1) {1};
 	\node[crecb,right=of bInnerRmd1,text width=7.5cm] (bInnerRmd20) {20 bytes};
 	\node[right=of bInnerRmd20] (checkInner2) { $)) $ };

--- a/whitepaper/chapters/blockchain.tex
+++ b/whitepaper/chapters/blockchain.tex
@@ -26,7 +26,7 @@ Otherwise, the difficulty is calculated from the last $n$ blocks in the followin
 \begin{align*}
 \tag{average difficulty} d &= \frac{1}{n}\sum_{i=1}^n (\text{difficulty of $block_i$}) \\
 \tag{average creation time} t &= \frac{1}{n}\sum_{i=1}^n (\text{time to create $block_i$}) \\
-\tag{new difficulty} \mathit{difficulty} &= d \; \frac{\nemsetting{network}{blockGenerationTargetTime}}{t}
+\tag{new difficulty} \mathvar{difficulty} &= d \; \frac{\nemsetting{network}{blockGenerationTargetTime}}{t}
 \end{align*}
 
 This algorithm produces blocks with an average time close to the desired \nemsetting{network}{blockGenerationTargetTime} network setting.
@@ -65,7 +65,7 @@ Block times will be considerably higher than \nemsetting{network}{blockGeneratio
 
 The score for a block is derived from its difficulty and the time (in seconds) that has elapsed since the last block:
 \begin{equation}
-\tag{block score} \mathit{score} = \mathit{difficulty} - \textit{time elasped since last block}
+\tag{block score} \mathvar{score} = \mathvar{difficulty} - \mathname{time elasped since last block}
 \end{equation}
 
 \subsection{Block Generation}
@@ -94,11 +94,11 @@ This makes running network nodes more profitable but harvesting less profitable.
 
 \index{block!fee multiplier}
 
-Each block must specify a \textit{fee multiplier} that determines the effective fee that must be paid by all transactions included in that block.
+Each block must specify a \emph{fee multiplier} that determines the effective fee that must be paid by all transactions included in that block.
 Typically, the node owner sets the \nemsetting{node}{minFeeMultiplier} that applies to all blocks harvested by the node.
 Only transactions that satisfy the following will be allowed to enter that node's unconfirmed transactions cache and be eligible for inclusion into blocks harvested by that node:
 \begin{equation}
-\textit{transaction max fee} \geqslant \nemsetting{node}{minFeeMultiplier} \cdot \textit{transaction size (bytes)}
+\mathname{transaction max fee} \geqslant \nemsetting{node}{minFeeMultiplier} \cdot \mathname{transaction size (bytes)}
 \end{equation}
 Rejected transactions may still be included in blocks harvested by other nodes with lower requirements.
 The specific algorithm used to select transactions for inclusion in harvested blocks is configured by the \nemsetting{node}{transactionSelectionStrategy} setting.
@@ -140,39 +140,40 @@ The latter adjustment ensures that the effective amounts are always nonzero.
 In order to arrive at the effective amount, the base amount is multiplied by the dynamic fee multiplier.
 
 \begin{align*}
-\textit{effective amount} = \: & \textit{base amount} \cdot \textit{dynamic fee multiplier}
+\mathname{effective amount} = \: & \mathname{base amount} \cdot \mathname{dynamic fee multiplier}
 \end{align*}
 
+\index{generation hash}
 \index{block!generation hash}
 
 The generation hash of a block is derived from the previous block generation hash and the public key of the current block harvester:
 \begin{align*}
 \tag{generation hash}
 \mathfunc{gh}(1) = \: & \nemsetting{network}{generationHash} \\
-\mathfunc{gh}(N) = \: & H(\mathfunc{gh}(N - 1), \textit{public key of account})
+\mathfunc{gh}(N) = \: & \hf(\mathfunc{gh}(N - 1), \mathname{public key of account})
 \end{align*}
 
 \index{block!hit}
 \index{block!target}
 To check if an account is allowed to create a new block at a specific network time, the following values are compared:
 \begin{itemize}
-\item{ $hit$: defines per-block value that needs to be \textit{hit}.}
+\item{ $hit$: defines per-block value that needs to be hit.}
 \item{ $target$: defines per-harvester power that increases as time since last harvested block increases.}
 \end{itemize}
-An account is allowed to create a new block whenever $\mathit{hit} < \mathit{target}$.
-Since $\mathit{target}$ is proportional to the elapsed time, a new block will be created after a certain amount of time even if all accounts are unlucky and generate a very high hit.
+An account is allowed to create a new block whenever $\mathvar{hit} < \mathvar{target}$.
+Since $\mathvar{target}$ is proportional to the elapsed time, a new block will be created after a certain amount of time even if all accounts are unlucky and generate a very high hit.
 
 In the case of delegated harvesting, the importance of the original account is used instead of the importance of the delegated account.
 
 The target is calculated as follows
 \footnote{The implementation uses 256-bit integer instead of floating point arithmetic in order to avoid any problems due to rounding.}:
 \begin{align*}
-\mathit{multiplier} = \: & 2^{64} \\
-t = \: & \textit{time in seconds since last block} \\
-b = \: & 8999999998 \: \cdot \: (\textit{account importance}) \\
-i = \: & \textit{total chain importance} \\
-d = \: & \textit{new block difficulty} \\
-\mathit{target} = \: & \frac{multiplier \cdot t \cdot b}{i \cdot d}
+\mathvar{multiplier} = \: & 2^{64} \\
+t = \: & \mathname{time in seconds since last block} \\
+b = \: & 8999999998 \: \cdot \: (\mathname{account importance}) \\
+i = \: & \mathname{total chain importance} \\
+d = \: & \mathname{new block difficulty} \\
+\mathvar{target} = \: & \frac{\mathvar{multiplier} \cdot t \cdot b}{i \cdot d}
 \end{align*}
 
 \emph{Block time smoothing}\index{block!time smoothing} can be enabled, which results in more stable block times.
@@ -184,14 +185,14 @@ If enabled, $multiplier$ above is calculated in the following way
 	If the calculated \field{power} is too negative, \field{smoothing} will be set to zero.
 }:
 \begin{align*}
-\mathit{factor} = \: & \nemsetting{network}{blockTimeSmoothingFactor} / 1000.0 \\
-\mathit{tt} = \: & \nemsetting{network}{blockGenerationTargetTime} \\
-\mathit{power} = \: & factor \cdot \frac{\textit{time in seconds since last block} - \mathit{tt}}{\mathit{tt}} \\
-\mathit{smoothing} = \: & \min\left(e^{\mathit{power}}, 100.0\right) \\
-\mathit{multiplier} = \: & \mathfunc{integer}\left(2^{54} \cdot \mathit{smoothing}\right) \cdot 2^{10}
+\mathvar{factor} = \: & \nemsetting{network}{blockTimeSmoothingFactor} / 1000.0 \\
+\mathvar{tt} = \: & \nemsetting{network}{blockGenerationTargetTime} \\
+\mathvar{power} = \: & factor \cdot \frac{\mathname{time in seconds since last block} - \mathvar{tt}}{\mathvar{tt}} \\
+\mathvar{smoothing} = \: & \min\left(e^{\mathvar{power}}, 100.0\right) \\
+\mathvar{multiplier} = \: & \mathfunc{integer}\left(2^{54} \cdot \mathvar{smoothing}\right) \cdot 2^{10}
 \end{align*}
 
-Hit is 64-bit approximation of $2^{54} \left|\ln\left(\frac{\mathit{gh}}{2^{256}}\right)\right|$, where $\mathit{gh}$ is a new generation hash
+Hit is 64-bit approximation of $2^{54} \left|\ln\left(\frac{\mathvar{gh}}{2^{256}}\right)\right|$, where $\mathvar{gh}$ is a new generation hash
 \footnote{
 	The implementation uses 128-bit integer instead of floating point arithmetic in order to avoid any problems due to rounding.
 	\texttt{log2(e)} is approximated as \texttt{14426950408889634 / 10000000000000000}.
@@ -199,27 +200,27 @@ Hit is 64-bit approximation of $2^{54} \left|\ln\left(\frac{\mathit{gh}}{2^{256}
 
 First, let's rewrite value above using $\log$ with base $2$:
 $$
-\textit{hit} = \frac{2^{54}}{\log_2\left(\euler\right)} \cdot \left|\log_2\left(\frac{gh}{2^{256}}\right)\right|
+\mathvar{hit} = \frac{2^{54}}{\log_2\left(\euler\right)} \cdot \left|\log_2\left(\frac{\mathvar{gh}}{2^{256}}\right)\right|
 $$
 
-Note, that $\frac{gh}{2^{256}}$ is always $< 1$, therefore $\log$ will always yield negative value. \\
-Now, $\log_2\left(\frac{gh}{2^{256}}\right)$, can be rewritten as $\log_2\left(gh\right) - \log_2\left(2^{256}\right)$. \\
+Note, that $\frac{\mathvar{gh}}{2^{256}}$ is always $< 1$, therefore $\log$ will always yield negative value. \\
+Now, $\log_2\left(\frac{\mathvar{gh}}{2^{256}}\right)$, can be rewritten as $\log_2\left(\mathvar{gh}\right) - \log_2\left(2^{256}\right)$. \\
 
 Dropping absolute value and rewriting yields:
 \begin{align*}
-	\mathit{scale} = \: & \frac{1}{\log_2\left(\euler\right)} \\
-	\mathit{hit} = \: & \mathit{scale} \cdot 2^{54} (\log_2\left(2^{256}\right) - \log_2\left(\mathit{gh}\right))
+	\mathvar{scale} = \: & \frac{1}{\log_2\left(\euler\right)} \\
+	\mathvar{hit} = \: & \mathvar{scale} \cdot 2^{54} (\log_2\left(2^{256}\right) - \log_2\left(\mathvar{gh}\right))
 \end{align*}
 
 This can be further simplified to:
 $$
-\mathit{hit} =  \mathit{scale} \cdot ( 2^{54} \cdot 256 -  2^{54} \cdot \log_2\left(\mathit{gh}\right))
+\mathvar{hit} =  \mathvar{scale} \cdot ( 2^{54} \cdot 256 -  2^{54} \cdot \log_2\left(\mathvar{gh}\right))
 $$
 
 The implementation approximates the logarithm using only the first 32 non-zero bits of the new generation hash.
 There's also additional handling for edge cases.
 
-Also note that $\mathit{hit}$ has an exponential distribution. Therefore, the probability to create a new block does not change if the importance is split among many accounts.
+Also note that $\mathvar{hit}$ has an exponential distribution. Therefore, the probability to create a new block does not change if the importance is split among many accounts.
 
 \subsection{Automatic Delegated Harvester Detection}
 
@@ -251,7 +252,7 @@ The server does not provide any explicit confirmation that it is or is not using
 
 A score can be assigned to any chain of blocks by summing the scores of the component blocks:
 \begin{equation}
-\tag{blockchain score} \mathit{score} = \sum_{\mathit{block} \in \mathit{blocks}} \textit{block score}
+\tag{blockchain score} \mathvar{score} = \sum_{\mathvar{block} \in \mathvar{blocks}} \mathname{block score}
 \end{equation}
 
 Blockchain synchronization is crucial to maintaining distributed consensus.

--- a/whitepaper/chapters/blockchain_sync_flowchart.tex
+++ b/whitepaper/chapters/blockchain_sync_flowchart.tex
@@ -1,3 +1,4 @@
+\index{synchronization}
 \index{block!synchronization}
 
 \begin{tikzpicture}[

--- a/whitepaper/chapters/blocks.tex
+++ b/whitepaper/chapters/blocks.tex
@@ -67,12 +67,12 @@ None of the unverifiable footer fields need to be verified.
 \subsection{Block Fields}
 
 \field{Height} is the block sequence number.
-The first block, called the \nind{nemesis block}, has a height of one.
+The first block, called the \nind{nemesis block}\index{block!nemesis}, has a height of one.
 Each successive block increments the height of the previous block by one.
 
 \field{Timestamp} is the number of milliseconds that have elapsed since the nemesis block.
 Each successive block must have a timestamp greater than that of the previous blocks because block time is strictly increasing.
-Each network tries to keep the average time between blocks close to \textit{target block time}.
+Each network tries to keep the average time between blocks close to \nind{target block time}.
 
 \field{Difficulty} is described in detail in \nemref{sec:blockchain:difficulty}.
 
@@ -250,9 +250,9 @@ Additionally, adding or removing functionality could change the number of reposi
 Instead, all root hashes are concatenated\footnote{The concatenation order is fixed and determined by the repository id.} and hashed to calculate the \field{StateHash},
 which is a single hash that deterministically fingerprints the global blockchain state.
 \begin{align*}
-\mathit{RepositoryHashes} = \: & 0 \\
-\mathit{RepositoryHashes} = \: & \sum_{0\leq i \leq N} \mathfunc{concat}(\mathit{RepositoryHashes}, \mathit{RepositoryHash}_i) \\
-\mathit{StateHash} = \: & H(\mathit{RepositoryHashes})
+\mathvar{RepositoryHashes} = \: & 0 \\
+\mathvar{RepositoryHashes} = \: & \sum_{0\leq i \leq N} \mathfunc{concat}(\mathvar{RepositoryHashes}, \mathvar{RepositoryHash}_i) \\
+\mathvar{StateHash} = \: & \hf(\mathvar{RepositoryHashes})
 \end{align*}
 
 \subsection{Extended Layout}

--- a/whitepaper/chapters/consensus.tex
+++ b/whitepaper/chapters/consensus.tex
@@ -82,7 +82,7 @@ Let $B_A$ represent the amount of currency owned by account $A$.
 The stake score for account $A$ is calculated for each eligible account as follows:
 
 \begin{equation}
-S_A = \frac{B_A}{\sum\limits_{\substack{a \in \textit{high value accounts}}} B_a}
+S_A = \frac{B_A}{\sum\limits_{\substack{a \in \mathname{high value accounts}}} B_a}
 \end{equation}
 
 The transaction score, $T_A$, for an account $A$ is the percentage of transaction fees it has paid relative to all fees paid by high value accounts within a time period $P$.
@@ -90,7 +90,7 @@ Let $\mathfunc{FeesPaid}{A}$ represent the amount of fees paid by $A$ in the tim
 The transaction score for account $A$ is calculated for each eligible account as follows:
 
 \begin{equation}
-T_A = \frac{\mathfunc{FeesPaid}(A)}{\sum\limits_{\substack{a \in \textit{high value accounts}}} \mathfunc{FeesPaid}(a)}
+T_A = \frac{\mathfunc{FeesPaid}(A)}{\sum\limits_{\substack{a \in \mathname{high value accounts}}} \mathfunc{FeesPaid}(a)}
 \end{equation}
 
 The node score, $N_A$, for an account $A$ is the percentage of times it has been specified as a beneficiary relative to the total number of high value account beneficiaries within a time period $P$.
@@ -98,7 +98,7 @@ Let $\mathfunc{BeneficiaryCount}{A}$represent the number of times $A$ has been s
 The node score for account $A$ is calculated for each eligible account as follows:
 
 \begin{equation}
-N_A = \frac{\mathfunc{BeneficiaryCount}(A)}{\sum\limits_{\substack{a \in \textit{high value accounts}}} \mathfunc{BeneficiaryCount}(a)}
+N_A = \frac{\mathfunc{BeneficiaryCount}(A)}{\sum\limits_{\substack{a \in \mathname{high value accounts}}} \mathfunc{BeneficiaryCount}(a)}
 \end{equation}
 
 Together, the transaction and node scores are called the \emph{activity score} because they are both dynamic and derived from an account's activity as opposed to its stake.
@@ -169,8 +169,8 @@ Given that, the spot importance of the account $A$, $I'_A$, can be calculated as
 }:
 \begin{align*}
 	\gamma = \: & \nemsetting{network}{importanceActivityPercentage} \\
-	\mathit{ActivityScore}'_A = \: & \frac{\nemsetting{network}{minHarvesterBalance}}{B_A} \cdot \left( 0.8 \cdot T_A + 0.2 \cdot N_A \right) \\
-	\mathit{ActivityScore}_A = \: & \frac{ActivityScore'_A}{\sum\limits_{\substack{a \in \textit{high value accounts}}} ActivityScore'_a} \\
+	\mathvar{ActivityScore}'_A = \: & \frac{\nemsetting{network}{minHarvesterBalance}}{B_A} \cdot \left( 0.8 \cdot T_A + 0.2 \cdot N_A \right) \\
+	\mathvar{ActivityScore}_A = \: & \frac{ActivityScore'_A}{\sum\limits_{\substack{a \in \mathname{high value accounts}}} ActivityScore'_a} \\
 	I'_A = \: & \nemsetting{network}{totalChainImportance} \cdot \left( \left(1 - \gamma \right) \cdot S_A + \gamma \cdot ActivityScore_A \right)
 \end{align*}
 

--- a/whitepaper/chapters/cryptography.tex
+++ b/whitepaper/chapters/cryptography.tex
@@ -21,9 +21,9 @@ Neither key generation nor signing is used during block processing, so the speed
 
 \subsection{Public/Private Key Pair}
 
-A \nind{private key} is a random 256-bit integer $k$. To derive the public key \underline{A} from it, the following steps are taken:
+A \nind{private key} is a random 256-bit integer $k$. To derive the public key\index{public key} \underline{A} from it, the following steps are taken:
 \begin{align}
-H(k) &=(h_0, h_1,..., h_{511}) \\
+\hf(k) &=(h_0, h_1,..., h_{511}) \\
 a &= 2^{254} + \sum_{3\leq i \leq 253} 2^i h_i \\
 A &= aB
 \end{align}
@@ -33,10 +33,10 @@ Since $A$ is a group element, it can be encoded into a 256-bit integer \underlin
 
 Given a message $M$, private key $k$ and its associated public key \underline{A}, the following steps are taken to create a signature:
 \begin{align}
-H(k) &=(h_0, h_1,..., h_{511}) \\
-r &= H(h_{256},...,h_{511}, M) \text{ where the comma means concatenation} \\
+\hf(k) &=(h_0, h_1,..., h_{511}) \\
+r &= \hf(h_{256},...,h_{511}, M) \text{ where the comma means concatenation} \\
 R &= rB \\
-S &= (r + H(\underline{R}, \underline{A}, M)a) \: mod \: q \label{eq:cryptography:S}
+S &= (r + \hf(\underline{R}, \underline{A}, M)a) \: mod \: q \label{eq:cryptography:S}
 \end{align}
 
 Then $(\underline{R}, \underline{S})$ is the \nind{signature} for the message $M$ under the private key $k$.
@@ -44,14 +44,14 @@ Note that only signatures where $S<q$ and $S>0$ are considered as valid \textbf{
 
 To verify the signature $(\underline{R}, \underline{S})$ for the given message $M$ and public key \underline{A}, the verifier checks $S<q$ and $S>0$ and then calculates
 \begin{align*}
-\tilde{R} = SB - H(\underline{R}, \underline{A}, M)A
+\tilde{R} = SB - \hf(\underline{R}, \underline{A}, M)A
 \end{align*}
 and verifies that
 \begin{equation}
 \tilde{R} = R \label{eq:cryptography:verifyR}
 \end{equation}
 If $S$ was computed as shown in \eqref{eq:cryptography:S} then
-$$SB = rB + (H(\underline{R}, \underline{A}, M)a)B = R + H(\underline{R}, \underline{A}, M)A$$
+$$SB = rB + (\hf(\underline{R}, \underline{A}, M)a)B = R + \hf(\underline{R}, \underline{A}, M)A$$
 so \eqref{eq:cryptography:verifyR} will hold.
 
 \subsection{Batch Verification}
@@ -59,7 +59,8 @@ so \eqref{eq:cryptography:verifyR} will hold.
 When lots of signatures have to be verified, a batch signature verification can speed up the process by about 80\%.
 \codenamespace uses the algorithm outlined in \cite{Bernstein2011}.
 Given a batch of $(M_i, A_i, R_i, S_i)$ where $(R_i, S_i)$ is the signature for the message $M_i$ with public key $A_i$,
-uniform distributed 128-bit independent random integers $z_i$ are generated and $H_i(R_i, A_i, M_i)$ is calculated.
+let $H_i = \hf(R_i, A_i, M_i)$.
+Additionally, assume a corresponding number of uniform distributed 128-bit independent random integers $z_i$ are generated.
 Now consider the equation
 \begin{align}
 \left(-\sum_i{z_i S_i \: \mathrm{mod} \: q}\right)B + \sum_i{z_i R_i} + \sum_i{(z_i H_i \: \mathrm{mod} \: q)A_i = 0} \label{eq:cryptography:verifyBatch}

--- a/whitepaper/chapters/disruptor.tex
+++ b/whitepaper/chapters/disruptor.tex
@@ -50,7 +50,7 @@ Therefore, consumers always need to act on input elements in a predefined order.
 To ensure this, each consumer has an associated barrier.
 The barrier prevents a consumer from processing an element that has not yet been processed by its immediately preceding consumer.
 The last consumer reclaims all memory that was used during processing.
-Consumers can set an element's completion status to \textit{Aborted} in case it is already known or invalid for some reason.
+Consumers can set an element's completion status to \structField{CompletionStatus}{Aborted} in case it is already known or invalid for some reason.
 Subsequent consumers ignore aborted elements.
 
 \begin{tikzpicture}[>=latex,font=\sffamily,thick,,scale=0.8]
@@ -183,7 +183,7 @@ For performance reasons, it is desirable to detect at an early stage whether an 
 The hash calculator consumer calculates all the hashes associated with an element.
 The hash check consumer uses the hashes to search the recency cache, which contains the hashes of all recently seen elements.
 The consumer used by the transaction disruptor will also search the hash cache (containing hashes of confirmed transactions) and the unconfirmed transactions cache.
-If the hash is found in any cache, the element is marked as \textit{Aborted} and further processing is bypassed.
+If the hash is found in any cache, the element is marked as \structField{CompletionStatus}{Aborted} and further processing is bypassed.
 
 \subsubsection*{Stateless Validation Consumer}
 This consumer handles state independent validation by validating each entity in an element.
@@ -195,7 +195,7 @@ This check depends on the network configuration but not on the global blockchain
 
 \subsubsection*{Batch Signature Consumer}
 This consumer validates all signatures of all entities in an element.
-This is separate from the \textit{Stateless Validation Consumer} because it uses batch verification.
+This is separate from the \emph{Stateless Validation Consumer} because it uses batch verification.
 For improved performance, this consumer processes many signatures at once in a batch instead of individually.
 This can be done in parallel using many threads.
 
@@ -235,7 +235,7 @@ Otherwise, all changes are committed to the chain state (both the block and cach
 
 \subsubsection*{Blockchain Sync Cleanup Consumer}
 This consumer is optional and can be enabled via node configuration.
-If enabled, it removes all files that were created by the \textit{Blockchain Sync Consumer}.
+If enabled, it removes all files that were created by the \emph{Blockchain Sync Consumer}.
 This consumer should only be enabled when a server is running without a broker.
 
 \subsubsection*{New Block Consumer}

--- a/whitepaper/chapters/network.tex
+++ b/whitepaper/chapters/network.tex
@@ -5,7 +5,7 @@
 Pulling a good network together takes effort, sincerity and time.
 }{Alan Collins}
 
-\nemchapterfirstletter{D}{ynamic} discovery of nodes allows a peer-to-peer network to grow.
+\nemchapterfirstletter{D}{ynamic} discovery of nodes\index{node} allows a peer-to-peer network to grow.
 \codenamespace implements this dynamic discovery in the \emph{node discovery extension}.
 Public networks are typically open and allow any node to join.
 Private networks can restrict the nodes that are allowed to join and behave as a federated system
@@ -19,7 +19,7 @@ Private networks can restrict the nodes that are allowed to join and behave as a
 
 A freshly booted node is initially isolated and not connected with any peers.
 It needs to join a network before it can make any meaningful contributions, like validating or harvesting blocks.
-In \codename, nominally \textit{static} beacon nodes are stored in a peers configuration file.
+In \codename, nominally \emph{static}\index{node!static} beacon nodes are stored in a peers configuration file.
 In order to join a network, a new node first connects to these nodes.
 These files don't need to be identical across all nodes in a network.
 
@@ -151,7 +151,7 @@ Possible provenances, ranked from best to worst are:
 \end{enumerate}
 
 It is important to note that the distinguishing characteristic of a \emph{static} node is that it appears in at least one peers configuration file.
-Excepting the \emph{local} node, all other nodes are \emph{dynamic}.
+Excepting the \emph{local} node, all other nodes are \emph{dynamic}\index{node!dynamic}.
 A subset of dynamic nodes are \emph{incoming}.
 These nodes have only been seen in incoming but not outgoing connections.
 As a result, their preferred port is unknown and they can't be connected with.
@@ -173,11 +173,11 @@ When there is an ambiguous match, data with the matching primary identity compon
 \label{sec:network:discovery}
 
 \codenamespace supports a configurable node identification policy configured by \nemsetting{network}{nodeEqualityStrategy}.
-Valid policies allow identifying a node by either its \textit{resolved IP} (\texttt{host})
+Valid policies allow identifying a node by either its \emph{resolved IP} (\texttt{host})
 \footnote{
 	A node's resolved IP is only broadcast to other nodes when it doesn't specify a hostname.
 	Hostnames are preferentially propagated in order to support nodes with dynamic IPs.
-}or \textit{public boot key} (\texttt{public-key}).
+}or \emph{public boot key} (\texttt{public-key}).
 The former is preferred for public networks.
 
 After starting up, a node attempts to make short lived connections to all static nodes it has loaded from its peers configuration files.

--- a/whitepaper/chapters/partial.tex
+++ b/whitepaper/chapters/partial.tex
@@ -8,12 +8,12 @@ The whole is greater than the sum of its parts.
 \nemchapterfirstletter{B}{onded} aggregate transactions \nemrefparens{sec:transactions:aggregate} are also referred to as partial transactions.
 The name \emph{partial} is fitting because the transactions have insufficient cosignatures and are unable to pass validation until more cosignatures are collected.
 
-Support for handling partial transactions is provided by the \textit{partial transaction extension}.
+Support for handling partial transactions is provided by the \emph{partial transaction extension}.
 If a network supports bonded aggregate transactions, this extension should be enabled on all Api and Dual nodes.
 
 Partial transactions are synchronized among all nodes in a network that have this extension enabled.
 A node passively receives partial transactions and cosignatures pushed by remote nodes.
-It also periodically requests transactions and cosignatures from remote nodes via the \textit{pull partial transactions task}.
+It also periodically requests transactions and cosignatures from remote nodes via the \emph{pull partial transactions task}.
 As an optimization, the requesting node indicates which transactions and cosignatures it already knows in order to avoid receiving redundant information.
 
 When the hash lock plugin is enabled, in order for a partial transaction to be accepted by the network, a hash lock must be created and associated with the transaction.
@@ -22,7 +22,7 @@ If the associated partial transaction is completed and confirmed in the blockcha
 Otherwise, the bond is forfeited to the harvester of the block at which the lock expires.
 This feature makes spamming the partial transactions cache more costly because it requires \nemsetting{node}{lockedFundsPerAggregate} to be paid, at least temporarily, for a partial transaction to enter the cache.
 
-When a node receives a new partial transaction, it is pushed to the \textit{partial transaction dispatcher}.
+When a node receives a new partial transaction, it is pushed to the \emph{partial transaction dispatcher}.
 Received cosignatures are collated with partial transactions already in the cache and are immediately rejected if there are no matching transactions
 \footnote{This implies that a partial transaction must be present in the cache before any of its cosignatures can be accepted.}.
 When transactions and cosignatures are received together, they are split and processed individually as above.

--- a/whitepaper/chapters/reputation.tex
+++ b/whitepaper/chapters/reputation.tex
@@ -18,7 +18,7 @@ One of the most successful is building a reputation system for nodes.
 This chapter will outline the heuristics used.
 
 \subsection{Connection Management}
-\index{reputation!connection!management}
+\index{reputation!connection management}
 \label{sec:reputation:ConnectionManagement}
 
 Each node can establish at most \nemsetting{node}{maxConnections} persistent connections at once.
@@ -31,7 +31,8 @@ The next time a node selection round is done, these connections are dropped and 
 This guarantees that over time each node will make connections to many different nodes in the network.
 
 \subsection{Weight Based Node Selection}
-\index{reputation!node!selection}
+\index{node!selection}
+\index{reputation!node selection|see {node, selection}}
 \label{sec:reputation:NodeSelection}
 
 Nodes primarily communicate with each other via the current persistent connections they have established.
@@ -54,7 +55,7 @@ Each candidate node is assigned a raw weight between 500 and 10000 according to 
 \begin{itemize}
 \item If there were 3 or fewer non-neutral interactions with the remote node, it is given a medium raw weight of 5000.
 This gives new nodes a good chance of getting selected.
-\item Else let \textit{s} be the number of successful and \textit{f} the number of failed interactions.
+\item Else let $s$ be the number of successful and $f$ the number of failed interactions.
 Then the raw weight is calculated by the following formula:
 
 \begin{figure}[t!]
@@ -76,7 +77,7 @@ Then the raw weight is calculated by the following formula:
 \end{figure}
 
 \begin{align*}
-\mathit{rawWeight} = \max\left(500, \frac{s \cdot 10000}{s + 9 \cdot f}\right)
+\mathvar{rawWeight} = \max\left(500, \frac{s \cdot 10000}{s + 9 \cdot f}\right)
 \end{align*}
 \end{itemize}
 
@@ -95,11 +96,12 @@ Each removal candidate that will be closed is replaced with a connection to a ne
 Finally, for each free slot, a candidate node has a chance of getting selected given by:
 
 \begin{align*}
-P(\textrm{node is getting selected}) = \frac{\textit{node weight}}{\sum\limits_{\substack{candidates\\nodes}} \textit{candidate node weight}}
+P(\textrm{node is getting selected}) = \frac{\mathname{node weight}}{\sum\limits_{\substack{candidates\\nodes}} \mathname{candidate node weight}}
 \end{align*}
 
 \subsection{Node Banning}
-\index{reputation!node!banning}
+\index{node!banning}
+\index{reputation!node banning|see {node, banning}}
 \label{sec:reputation:NodeBanning}
 
 In a public network there could be potentially malicious nodes that try to disturb normal processing of the network.

--- a/whitepaper/chapters/system.tex
+++ b/whitepaper/chapters/system.tex
@@ -9,7 +9,7 @@ A new technology can transform society, but when the technology is in its infanc
 Network-wide settings, specified in \nemsetting{network}{network}, must be the same for all nodes in a network.
 In contrast, node-specific settings can vary across all nodes in the same network, and are located in \nemsetting{node}{node}.
 
-\codenamespace was designed to use a \textit{plugin / extension} approach instead of supporting Turing complete smart contracts.
+\codenamespace was designed to use a \emph{plugin / extension} approach instead of supporting Turing complete smart contracts.
 While the latter can allow for more user flexibility, it's also more error prone from the user perspective.
 A plugin model limits the operations that can be performed on a blockchain and consequently has a smaller attack surface.
 Additionally, it's much simplier to optimize the performance of a discrete set of operations than an infinite set.
@@ -18,7 +18,7 @@ This helps \codenamespace achieve the high throughput for which it was designed.
 \subsection{Transaction Plugins}
 
 All nodes in a network must support the same types of transactions and process them in exactly the same manner so that all nodes can agree on the global blockchain state.
-The network requires each node to load a set of \textit{transaction plugins}, and this set determines the kinds of transactions the network supports.
+The network requires each node to load a set of \emph{transaction plugins}\index{plugins}, and this set determines the kinds of transactions the network supports.
 This set is determined by the presence of \nemsetting{network}{plugin*} sections in the \nemsetting{network}{network} configuration.
 Any changes, additions or deletions of these plugins must be coordinated and accepted by all network nodes.
 If only a subset of nodes agree to these modifications, those nodes will be on a fork.
@@ -69,7 +69,7 @@ Through this class, a plugin can register zero or more of the following:
 Individual nodes within a network are allowed to support a heterogeneous mix of capabilities.
 For example, some nodes might want to store data in a database or publish events to a message queue.
 These capabilities are all optional because none of them impact consensus.
-Such capabilities are determined by the set of \textit{extensions} a node loads as specified in \nemsetting{extensions-\{process\}}{extensions}.
+Such capabilities are determined by the set of \nind{extensions} a node loads as specified in \nemsetting{extensions-\{process\}}{extensions}.
 Most built-in \codenamespace functionality is built using this extension model in order to validate its extensibility.
 
 An extension is a separate dynamically linked library that exposes a single entry point in the following form

--- a/whitepaper/chapters/timesync.tex
+++ b/whitepaper/chapters/timesync.tex
@@ -48,9 +48,9 @@ The partner node uses its own network time to create the timestamps.
 \end{figure}
 
 Using the timestamps, the local node can calculate the round trip time
-$$\mathit{rtt}=(t_4 - t_1) - (t_3 - t_2)$$
+$$\mathvar{rtt} = (t_4 - t_1) - (t_3 - t_2)$$
 and then estimate the offset o between the network time used by the two nodes as
-$$o = t_2 - t_1 - \frac{\mathit{rtt}}{2}$$
+$$o = t_2 - t_1 - \frac{\mathvar{rtt}}{2}$$
 
 This is repeated for every time synchronization partner until the local node has a list of offset estimations.
 
@@ -89,13 +89,13 @@ Also, the numbers of samples that are available and the cumulative importance of
 Each offset is therefore multiplied with a scaling factor.
 
 Let $I_j$ be the importance of the node reporting the $j$-th offset $o_j$,
-$\textit{n}$ be the number of nodes that were eligible for the last PoI calculation and $\textit{s}$ be the number of samples.
+$n$ be the number of nodes that were eligible for the last PoI calculation and $s$ be the number of samples.
 
 Then the scaling factor used is
-$$ \mathit{scale} = \min\left(\frac{1}{\sum_j I_j}, \frac{1}{\frac{s}{n}}\right)$$
+$$ \mathvar{scale} = \min\left(\frac{1}{\sum_j I_j}, \frac{1}{\frac{s}{n}}\right)$$
 
 This gives the formula for the effective offset $o$
-$$ o = \mathit{scale} \sum_j I_j \: o_j$$
+$$ o = \mathvar{scale} \sum_j I_j \: o_j$$
 
 Note that the influence of an account with large importance is artificially limited because the term $\frac{n}{s} $ caps the scale.
 Such an account can raise its influence on a macro level by splitting its balance into accounts that are not capped.
@@ -113,7 +113,7 @@ Each node keeps track of the number of time synchronization rounds it has perfor
 This is called the node age.
 
 The formula for this coupling factor $c$ is:
-$$c = \max\left(e^{-0.3a},\: 0.1\right) \; \text{where} \; a = \max(nodeAge - 5,\: 0)$$
+$$c = \max\left(\euler^{-0.3a},\: 0.1\right) \; \text{where} \; a = \max(nodeAge - 5,\: 0)$$
 
 This ensures that the coupling factor will be 1 for 5 rounds and then decay exponentially to 0.1.
 

--- a/whitepaper/chapters/transactions.tex
+++ b/whitepaper/chapters/transactions.tex
@@ -184,7 +184,7 @@ $$\mathfunc{verify}(\structField{A}{Signature}, \structField{A}{SignerPublicKey}
 
 Additionally, all cosignatures must pass signature verification.
 Notice that cosigners sign the hash of an aggregate transaction data, not the data directly.
-$$\sum_{0\leq i \leq N_C} \mathfunc{verify}(\structField{C}{Signature}, \structField{C}{SignerPublicKey}, H(\mathfunc{VerifiableDataBuffer}(A)))$$
+$$\sum_{0\leq i \leq N_C} \mathfunc{verify}(\structField{C}{Signature}, \structField{C}{SignerPublicKey}, \hf(\mathfunc{VerifiableDataBuffer}(A)))$$
 
 Finally, there must be a cosignature that corresponds to and satisfies each embedded transaction signer.
 

--- a/whitepaper/chapters/trees.tex
+++ b/whitepaper/chapters/trees.tex
@@ -33,20 +33,20 @@ In the \codenamespace implementation, when any (non-root) layer contains an odd 
 \begin{figure}[h]
 	\nemtree{
 		\tikzstyle{level 3}=[sibling distance=8em]
-		\node {Merkle Hash = $H_{Root}$ =\\H($H_{ABCD}$, $H_{EE^2}$)}
-			child [sibling distance=16em] { node {$H_{ABCD}$ =\\H($H_{AB}$, $H_{CD}$)}
-				child { node {$H_{AB}$ =\\H(H(A), H(B))}
-					child { node {H(A)} { child { node {A} } } }
-					child { node {H(B)} { child { node {B} } } }
+		\node {Merkle Hash = $H_{Root}$ =\\ $\hf(H_{ABCD}, H_{EE^2})$}
+			child [sibling distance=16em] { node {$H_{ABCD}$ =\\ $\hf(H_{AB}, H_{CD})$}
+				child { node {$H_{AB}$ =\\ $\hf(\hf(A), \hf(B))$}
+					child { node { $\hf(A)$ } { child { node {A} } } }
+					child { node { $\hf(B)$ } { child { node {B} } } }
 				}
-				child { node {$H_{CD}$ =\\H(H(C), H(D))}
-					child { node {H(C)} { child { node {C} } } }
-					child { node {H(D)} { child { node {D} } } }
+				child { node {$H_{CD}$ =\\ $\hf(\hf(C), \hf(D))$ }
+					child { node { $\hf(C)$ } { child { node {C} } } }
+					child { node { $\hf(D)$ } { child { node {D} } } }
 				}
 			}
-			child [sibling distance=16em] { node {$H_{EE^2}$ =\\H($H_{EE}$, $H_{EE}$)}
-				child { node {$H_{EE}$ =\\H(H(E), H(E))}
-					child { node {H(E)} { child { node {E} } } }
+			child [sibling distance=16em] { node {$H_{EE^2}$ =\\ $\hf(H_{EE}, H_{EE})$}
+				child { node {$H_{EE}$ =\\ $\hf(\hf(E), \hf(E))$ }
+					child { node { $\hf(E)$ } { child { node {E} } } }
 				}
 			};
 	}{Four level Merkle tree composed of five data items}
@@ -56,20 +56,20 @@ In the \codenamespace implementation, when any (non-root) layer contains an odd 
 	\nemtree{
 		\tikzset{ highlight/.style = {fill = yellow} }
 		\tikzstyle{level 3}=[sibling distance=8em]
-		\node [highlight] {Merkle Hash = $H_{Root}$ =\\H($H_{ABCD}$, $H_{EE^2}$)}
-			child [sibling distance=16em] { node {$H_{ABCD}$ =\\H($H_{AB}$, $H_{CD}$)}
-				child { node {$H_{AB}$ =\\H(H(A), H(B))}
-					child { node [highlight] {H(A)} { child { node {A} } } }
-					child { node {H(B)} { child { node [highlight] {B} } } }
+		\node [highlight] {Merkle Hash = $H_{Root}$ =\\ $\hf(H_{ABCD}, H_{EE^2})$}
+			child [sibling distance=16em] { node {$H_{ABCD}$ =\\ $\hf(H_{AB}, H_{CD})$}
+				child { node {$H_{AB}$ =\\ $\hf(\hf(A), \hf(B))$ }
+					child { node [highlight] { $\hf(A)$ } { child { node {A} } } }
+					child { node { $\hf(B)$ } { child { node [highlight] {B} } } }
 				}
-				child { node [highlight] {$H_{CD}$ =\\H(H(C), H(D))}
-					child { node {H(C)} { child { node {C} } } }
-					child { node {H(D)} { child { node {D} } } }
+				child { node [highlight] {$H_{CD}$ =\\ $\hf(\hf(C), \hf(D))$ }
+					child { node { $\hf(C)$ } { child { node {C} } } }
+					child { node { $\hf(D)$ } { child { node {D} } } }
 				}
 			}
-			child [sibling distance=16em] { node [highlight] {$H_{EE^2}$ =\\H($H_{EE}$, $H_{EE}$)}
-				child { node {$H_{EE}$ =\\H(H(E), H(E))}
-					child { node {H(E)} { child { node {E} } } }
+			child [sibling distance=16em] { node [highlight] {$H_{EE^2}$ =\\ $\hf(H_{EE}, H_{EE})$}
+				child { node {$H_{EE}$ =\\ $\hf(\hf(E), \hf(E))$ }
+					child { node { $\hf(E)$ } { child { node {E} } } }
 				}
 			};
 	}{Merkle proof required for proving existence of B in the tree}
@@ -81,11 +81,11 @@ This allows for existence proofs with relatively low bandwidth requirements.
 A merkle proof for existence requires a single hash from each level of the tree.
 In order to prove the existence of $B$, a client must:
 \begin{enumerate}
-	\item{Calculate $H(B)$}
+	\item{Calculate $\hf(B)$}
 	\item{Obtain $H_{Root}$; in \codename, this is stored in the block header}
-	\item{Request $H(A)$, $H_{CD}$, $H_{EE^2}$}
-	\item{Calculate $H_{Root'} = H(H(H(H(A), H(B)), H_{CD}), H_{EE^2})$}
-	\item{Compare $H_{Root}$ and $H_{Root'}$; if they match $H(B)$ must be stored in the tree}
+	\item{Request $\hf(A), H_{CD}, H_{EE^2}$}
+	\item{Calculate $H_{Root'} = \hf(\hf(\hf(\hf(A), \hf(B)), H_{CD}), H_{EE^2})$}
+	\item{Compare $H_{Root}$ and $H_{Root'}$; if they match $\hf(B)$ must be stored in the tree}
 \end{enumerate}
 
 \subsection{Patricia Tree}
@@ -224,22 +224,24 @@ If the path is composed of an even number, the second nibble will be set to $\te
 	}{Tree node path encoding}
 \end{figure}
 
-A \emph{leaf node}\index{node!leaf} is composed of the following two items:
+A \emph{leaf node}\index{tree!leaf} is composed of the following two items:
 \begin{enumerate}
 	\item{TreeNodePath: Encoded tree node path (with leaf bit set).}
 	\item{ValueHash: Hash of the value associated with the key ending at the leaf.}
 \end{enumerate}
 
-The hash of a leaf node can be calculated by hashing its component parts: $$\textit{H(Leaf)}=H(TreeNodePath, ValueHash)$$.
+The hash of a leaf node can be calculated by hashing its component parts:
+$$\hf(\mathvar{Leaf}) = \hf(\mathvar{TreeNodePath}, \mathvar{ValueHash})$$.
 
-A \emph{branch node}\index{node!branch} is composed of the following items:
+A \emph{branch node}\index{tree!branch} is composed of the following items:
 \begin{enumerate}
 	\item{TreeNodePath: Encoded tree node path (with leaf bit unset).}
-	\item{$LinkHash_{0...15}$: Hashes of children where the index is the next nibble part of the path.
+	\item{$\mathvar{LinkHash}_{0}, \ldots, \mathvar{LinkHash}_{15}$: Hashes of children where the index is the next nibble part of the path.
 	When no child is present at an index, a zero hash should be used instead.}
 \end{enumerate}
 
-The hash of a branch node can be calculated by hashing its component parts: $$\textit{H(Branch)}=H(TreeNodePath, LinkHash_0,..LinkHash_{15})$$.
+The hash of a branch node can be calculated by hashing its component parts:
+$$\hf(\mathvar{Branch}) = \hf(\mathvar{TreeNodePath}, \mathvar{LinkHash}_0,\ldots,\mathvar{LinkHash}_{15})$$.
 
 Reconstructing the earlier example with hex keys yields a tree that illustrates a more accurate view of how a \codenamespace tree is constructed.
 Notice that each branch node index composes a single nibble of the path.
@@ -277,23 +279,23 @@ This is depicted in \autoref{fig:trees:hexCompact}.
 \subsection{Merkle Patricia Tree Proofs}
 
 A merkle proof for existence requires a single node from each level of the tree.
-In order to prove the existence of $\{key = \texttt{646F6765}, value = H(mascot)\}$, a client must:
+In order to prove the existence of $\{key = \texttt{646F6765}, value = \hf(mascot)\}$, a client must:
 \begin{enumerate}
-	\item{Calculate $H(mascot)$ (remember, all leaf values are hashes).}
+	\item{Calculate $\hf(mascot)$ (remember, all leaf values are hashes).}
 	\item{Request all nodes on the path $\texttt{646F6765}$: $Node_{6}$, $Node_{646F}$, $Node_{646F67}$.}
-	\item{Verify that $Node_{646F67}::Link[6]$ is equal to $H(Leaf(mascot))$.}
-	\item{Calculate $H(Node_{646F67})$ and verify that $Node_{6467}::Link[6]$ is equal to $H(Node_{646F67})$.}
-	\item{Calculate $H(Node_{6467})$ and verify that $Node_{6}::Link[4]$ is equal to $H(Node_{6467})$.}
+	\item{Verify that $Node_{646F67}::Link[6]$ is equal to $\hf(\mathfunc{Leaf}(mascot))$.}
+	\item{Calculate $\hf(Node_{646F67})$ and verify that $Node_{6467}::Link[6]$ is equal to $\hf(Node_{646F67})$.}
+	\item{Calculate $\hf(Node_{6467})$ and verify that $Node_{6}::Link[4]$ is equal to $\hf(Node_{6467})$.}
 	\item{Existence is proven if all calculated and actual hashes match.}
 \end{enumerate}
 
 A merkle proof for non-existence requires a single node from each level of the tree.
-In order to prove the non-existence of $\{key = \texttt{646F6764}, value = H(mascot)\}$, a client must:
+In order to prove the non-existence of $\{key = \texttt{646F6764}, value = \hf(mascot)\}$, a client must:
 \begin{enumerate}
-	\item{Calculate $H(mascot)$ (remember, all leaf values are hashes).}
+	\item{Calculate $\hf(mascot)$ (remember, all leaf values are hashes).}
 	\item{Request all nodes on the path $\texttt{646F6764}$: $Node_{6}$, $Node_{646F}$, $Node_{646F67}$.}
 	\item{
-		Verify that $Node_{646F67}::Link[5]$ is equal to $H(Leaf(mascot))$.
+		Verify that $Node_{646F67}::Link[5]$ is equal to $\hf(\mathfunc{Leaf}(mascot))$.
 		Since $Link[5]$ is unset, this check will fail.
 		If the value being searched for was in the tree, it must be linked to this node because of the determinism of the tree.
 	 }

--- a/whitepaper/chapters/unconfirmed.tex
+++ b/whitepaper/chapters/unconfirmed.tex
@@ -6,10 +6,10 @@ I don’t believe one reads to escape reality.
 A person reads to confirm a reality he knows is there, but which he has not experienced.
 }{Lawrence Durrell}
 
-\nemchapterfirstletter{A}{ny} transaction that is not yet included in a block is called an \textit{unconfirmed transaction}.
+\nemchapterfirstletter{A}{ny} transaction that is not yet included in a block is called an \emph{unconfirmed transaction}.
 These transactions may be valid or invalid.
 Valid unconfirmed transactions are eligible for inclusion in a harvested block.
-Once a transaction is added to a block that is accepted in the blockchain, it is \textit{confirmed}.
+Once a transaction is added to a block that is accepted in the blockchain, it is \emph{confirmed}.
 
 Unconfirmed transactions can arrive at a node when:
 \begin{enumerate}
@@ -29,10 +29,10 @@ Due to different node settings, it's possible for some nodes to accept a specifi
 For example, the nodes could have different \nemsetting{node}{minFeeMultiplier} settings.
 
 \subsection{Unconfirmed Transactions Cache}
-\index{unconfirmedTransactions!cache}
+\index{unconfirmed transactions!cache}
 
 When a transaction passes all validation, it is eligible for inclusion in a harvested block.
-At this point, the node tries to add it to the \textit{unconfirmed transactions cache}.
+At this point, the node tries to add it to the \emph{unconfirmed transactions cache}.
 This can fail for two reasons:
 \begin{enumerate}
 	\item{The maximum cache size configured by \nemsetting{node}{unconfirmedTransactionsCacheMaxSize} has been reached.}
@@ -51,7 +51,7 @@ Each transaction is rechecked by the stateful validators and purged if it has be
 Otherwise, it is added back to the cache.
 
 \subsection{Spam Throttle}
-\index{unconfirmedTransactions!spamThrottle}
+\index{unconfirmed transactions!spam throttle}
 
 The initiator of an unconfirmed transaction does not have to pay a fee to nodes holding the transaction in the unconfirmed transactions cache.
 Since the cache uses valuable resources, a node must have some protection against being spammed with lots of unconfirmed transactions.
@@ -69,14 +69,14 @@ Assuming the cache is not full, it works in the following way:
 	\item{Else the Spam throttle is applied.}
 \end{enumerate}
 
-Let \textit{curSize} be the current number of transactions in the cache and \textit{maxSize} the configured maximum size of the cache.
-Also let \textit{rel. importance of A} be the relative importance of $A$, i.e. a number between 0 and 1.
-If a new unconfirmed transaction with signer $A$ arrives, then the \textit{fair share} for account $A$ is calculated:
+Let $\mathvar{curSize}$ be the current number of transactions in the cache and $\mathvar{maxSize}$ the configured maximum size of the cache.
+Also let $\mathname{rel. importance of A}$ be the relative importance of $A$, i.e. a number between 0 and 1.
+If a new unconfirmed transaction $T$ with signer $A$ arrives, then the $\mathname{fair share}$ for account $A$ is calculated:
 \begin{align*}
-	\textit{maxBoostFee} &= \text{\nemsetting{node}{transactionSpamThrottlingMaxBoostFee}} \\
-	\textit{maxFee} &= \min(\textit{maxBoostFee}, \structField{transaction}{MaxFee}) \\
-	\textit{eff. importance} &= (\textit{rel. importance of A}) + 0.01 \cdot \frac{\textit{maxFee}}{\textit{maxBoostFee}} \\
-	\textit{fair share} &= 100 \cdot (\textit{eff. importance}) \cdot (\textit{maxSize} - \textit{curSize}) \cdot \exp\left(-3 \frac{\textit{curSize}}{\textit{maxSize}}\right)
+	\mathvar{maxBoostFee} &= \nemsetting{node}{transactionSpamThrottlingMaxBoostFee} \\
+	\mathvar{maxFee} &= \min(\mathvar{maxBoostFee}, \structField{T}{MaxFee}) \\
+	\mathname{eff. importance} &= (\mathname{rel. importance of A}) + 0.01 \cdot \frac{\mathvar{maxFee}}{\mathvar{maxBoostFee}} \\
+	\mathname{fair share} &= 100 \cdot (\mathname{eff. importance}) \cdot (\mathvar{maxSize} - \mathvar{curSize}) \cdot \exp\left(-3 \frac{\mathvar{curSize}}{\mathvar{maxSize}}\right)
 \end{align*}
 
 If account $A$ already has as many transactions in the cache as its fair share, then the new transaction is rejected.

--- a/whitepaper/header/commands.tex
+++ b/whitepaper/header/commands.tex
@@ -7,13 +7,18 @@
 \newcommand{\euler}{\mathrm{e}}
 
 % math formatting
-\newcommand{\mathfunc}[1]{\mathrm{#1}}
-\newcommand{\structField}[2]{#1\mathrm{{::}#2}}
+\newcommand{\mathfunc}[1]{\operatorname{#1}}
+\newcommand{\mathvar}[1]{\mathit{#1}}
+\newcommand{\mathname}[1]{\textit{#1}}
+\newcommand{\structField}[2]{%
+	\ifmmode#1{\allowbreak}\mathrm{{::}{\allowbreak}#2}\else\texttt{#1{\allowbreak}::{\allowbreak}#2}\fi
+}
+
+% alias for hash used in many places
+\newcommand{\hf}{\operatorname{H}}
 
 % nem index
-\newcommand{\nind}[1]{
-	\emph{#1}\index{#1}
-}
+\newcommand{\nind}[1]{\emph{#1}\index{#1}}
 
 % reference formatting
 \newcommand{\nemref}[1]{\autoref{#1}:~\nameref{#1}}

--- a/whitepaper/preface.tex
+++ b/whitepaper/preface.tex
@@ -21,7 +21,7 @@ We are hopeful that this fixes many of the problems inherent in NIS1 and provide
 Our mandate was to build a high performance *blockchain* - not a DAG or dBFT based system.
 In this, we think, we succeeded.
 
-This has been a long journey for us, but we are excited to see what yet is to come and what novel things \textit{you} use \codenamespace to build.
+This has been a long journey for us, but we are excited to see what yet is to come and what novel things \textbf{you} use \codenamespace to build.
 We would like to once again thank the contributors and the many people who have inspired us\ldots
 
 \begin{flushright}


### PR DESCRIPTION
1. Introduces `\mathvar` and `\mathname`
2. `\hf` to use operatorname for H() which is frequently used (`\h` was already taken #sadpanda)
3. some index changes / fixes
4. removal of any leftover `textit` in favor of emph
