### PR TITLE
Update consensus.tex

### DIFF
--- a/whitepaper/chapters/consensus.tex
+++ b/whitepaper/chapters/consensus.tex
@@ -38,7 +38,7 @@ This necessarily leads to a computational arms race and uses a lot of electricit
 Proof of Stake (PoS)\cite{King:2012:PPP}\cite{Nxt2013} blockchains were introduced after Bitcoin.
 They presented an alternative solution to the Byzantine consensus problem that did not require significant power consumption.
 Fundamentally, these chains behaved similarly to Bitcoin with one important difference.
-Instead of predicting the probability of creating a block on a node's relative hash rate, the probability is based on a node's relative stake in the network.
+Instead of predicating the probability of creating a block on a node's relative hash rate, the probability is based on a node's relative stake in the network.
 Since richer accounts are able to produce more blocks than poorer accounts, this scheme tends to allow the rich to get richer.
 
 \codenamespace uses a modified version of PoS that borrows key concepts from Proof of Importance (PoI).
@@ -104,7 +104,7 @@ N_A = \frac{\mathfunc{BeneficiaryCount}(A)}{\sum\limits_{\substack{a \in \mathna
 Together, the transaction and node scores are called the \emph{activity score} because they are both dynamic and derived from an account's activity as opposed to its stake.
 The transaction score is weighted at 80\% and the node score at 20\%.
 Additionally, the combined score is scaled relative to an account's balance so that there is a dampening effect of activity on importance as stake increases
-\footnote{The activity score is rescaled after dampening so that it contributes to the desired \nemsetting{network}{importanceActivityPercentage} to the importance calculation.}.
+\footnote{The activity score is rescaled after dampening so that it contributes the desired \nemsetting{network}{importanceActivityPercentage} to the importance calculation.}.
 This effectively allows active smaller accounts to gain an outsized boost relative to active larger accounts.
 This partially redistributes importance away from rich accounts towards poorer accounts and somewhat counteracts the rich getting richer phenomenon inherent in PoS.
 The prominence of activity relative to stake can be configured by \nemsetting{network}{importanceActivityPercentage}.
@@ -164,7 +164,7 @@ The \nemsetting{network}{totalChainImportance} setting specifies the total impor
 Given that, the spot importance of the account $A$, $I'_A$, can be calculated as follows
 \footnote{
 	There is some additional edge case handling that is not reflected in the equation around how zero component scores are handled.
-	If either the transaction or node scores are zero, the other will be scaled up and serve as the fully weighted activity score.
+	If either the transaction or node scores is zero, the other will be scaled up and serve as the fully weighted activity score.
 	If both are zero, the stake score will be scaled up and used exclusively.
 }:
 \begin{align*}

--- a/whitepaper/chapters/consensus.tex
+++ b/whitepaper/chapters/consensus.tex
@@ -49,7 +49,7 @@ All else equal, accounts with larger stakes making more transactions and running
 Firstly, accounts with larger balances have larger stakes in the network and have greater incentives to see the ecosystem as a whole succeed.
 The amount of the currency an account owns is a measure of its stake.
 Secondly, accounts should be encouraged to use the network by making transactions.
-Network usage can be approximated by the total amount of fees paid by an account.
+Network usage can be approximated by the total amount of transaction fees paid by an account.
 Thirdly, accounts should be encouraged to run nodes to strengthen the network.
 This can be approximated by the number of times an account is the beneficiary of a block
 \footnote{
@@ -270,7 +270,7 @@ Second, in order to execute a successful nothing at stake attack, the attacker m
 Third, successful execution of this attack against the network will likely have a negative influence on the currency value.
 Since other harvesters, by harvesting on all forks, enable this attack, profit-maximizing harvesters should only harvest on a single chain to preclude it.
 
-In the second variation, a single attacker harvests on all forks and attempts to capture all fees irrespective of which chain becomes the reference chain.
+In the second attack variation, a single attacker harvests on all forks and attempts to capture all fees irrespective of which chain becomes the reference chain.
 An attacker could harvest on all forks starting from the second block searching for the chain in which the attacker has harvested the most fees.
 Since block acceptance is probabilistic, in theory, an attacker could spend infinite time building the perfect chain in which the attacker has harvested all blocks.
 
@@ -347,7 +347,7 @@ These fees are lost to other harvesters because the probability of the account h
 The high fees paid boost the account’s importance enough so that it is able to harvest at least one block per importance recalculation interval.
 From this point forward, the account behaves like the large account in the previous section.
 It will also add a transaction with a high fee to one of its own harvested blocks each recalculation interval.
-The account hopes that due to the increased probability of harvesting a block, its additional collected fees will exceed its costs.
+The account operator hopes that due to the increased probability of harvesting a block, its additional collected fees will exceed its costs.
 
 \begin{figure}[H]
 	\nemcenterwithcaption{

--- a/whitepaper/chapters/consensus.tex
+++ b/whitepaper/chapters/consensus.tex
@@ -38,7 +38,7 @@ This necessarily leads to a computational arms race and uses a lot of electricit
 Proof of Stake (PoS)\cite{King:2012:PPP}\cite{Nxt2013} blockchains were introduced after Bitcoin.
 They presented an alternative solution to the Byzantine consensus problem that did not require significant power consumption.
 Fundamentally, these chains behaved similarly to Bitcoin with one important difference.
-Instead of predicating the probability of creating a block on a node's relative hash rate the probability is based on a node's relative stake in the network.
+Instead of predicting the probability of creating a block on a node's relative hash rate, the probability is based on a node's relative stake in the network.
 Since richer accounts are able to produce more blocks than poorer accounts, this scheme tends to allow the rich to get richer.
 
 \codenamespace uses a modified version of PoS that borrows key concepts from Proof of Importance (PoI).
@@ -51,7 +51,7 @@ The amount of the currency an account owns is a measure of its stake.
 Secondly, accounts should be encouraged to use the network by making transactions.
 Network usage can be approximated by the total amount of fees paid by an account.
 Thirdly, accounts should be encouraged to run nodes to strengthen the network.
-This can approximated by the number of times an account is the beneficiary of a block
+This can be approximated by the number of times an account is the beneficiary of a block
 \footnote{
 	This measure is strongly correlated with stake when all accounts are actively running nodes.
 	Its intent is to differentiate accounts running nodes from accounts idling.
@@ -104,7 +104,7 @@ N_A = \frac{\mathfunc{BeneficiaryCount}(A)}{\sum\limits_{\substack{a \in \mathna
 Together, the transaction and node scores are called the \emph{activity score} because they are both dynamic and derived from an account's activity as opposed to its stake.
 The transaction score is weighted at 80\% and the node score at 20\%.
 Additionally, the combined score is scaled relative to an account's balance so that there is a dampening effect of activity on importance as stake increases
-\footnote{The activity score is rescaled after dampening so that it contributes the desired \nemsetting{network}{importanceActivityPercentage} to the importance calculation.}.
+\footnote{The activity score is rescaled after dampening so that it contributes to the desired \nemsetting{network}{importanceActivityPercentage} to the importance calculation.}.
 This effectively allows active smaller accounts to gain an outsized boost relative to active larger accounts.
 This partially redistributes importance away from rich accounts towards poorer accounts and somewhat counteracts the rich getting richer phenomenon inherent in PoS.
 The prominence of activity relative to stake can be configured by \nemsetting{network}{importanceActivityPercentage}.
@@ -164,7 +164,7 @@ The \nemsetting{network}{totalChainImportance} setting specifies the total impor
 Given that, the spot importance of the account $A$, $I'_A$, can be calculated as follows
 \footnote{
 	There is some additional edge case handling that is not reflected in the equation around how zero component scores are handled.
-	If either the transaction or node scores is zero, the other will be scaled up and serve as the fully weighted activity score.
+	If either the transaction or node scores are zero, the other will be scaled up and serve as the fully weighted activity score.
 	If both are zero, the stake score will be scaled up and used exclusively.
 }:
 \begin{align*}
@@ -238,7 +238,7 @@ This implies that the virtual nodes are running on a strong physical server, whi
 \subsubsection*{Boosting Transaction Score}
 
 The transaction score is solely based on fees.
-There is no difference between one huge account spending $X$ on fees and $N$ smaller accounts each spending $\frac{X}{N}$ on fees.
+There is no difference between one huge account spending $X$ on fees and $N$ smaller accounts, each spending $\frac{X}{N}$ on fees.
 For emphasis:
 
 \begin{equation}
@@ -255,7 +255,7 @@ There are two variations of this attack.
 
 In the first variation, all harvesters except the attacker harvest on all forks.
 Simplifying the description to assume a binary fork, the attacker would submit a payment to one branch and immediately start harvesting on the other branch.
-Assuming the attacker has sufficient importance to harvest blocks, eventually the branch without the attacker's payment will become the reference chain because it will have a a higher score
+Assuming the attacker has sufficient importance to harvest blocks, eventually the branch without the attacker's payment will become the reference chain because it will have a higher score
 \footnote{This assumes that there is only a single attacker or all attackers collude to withhold harvesting from the same branch.}.
 The attacker's payment is not included in this branch, so the attacker's funds are effectively returned.
 
@@ -292,7 +292,7 @@ Since the attacker can't know all the blocks that will be confirmed in the inter
 A \emph{fee attack} is an attempt by an attacker to exploit the transaction score by paying large fees in order to boost its own importance.
 The attack is considered effective if it yields a positive expected value.
 
-The analysis in this section will be performed using recommended public network settings.
+The analysis in this section will be performed using the recommended public network settings.
 These include \nemsetting{network}{totalChainImportance} equal to 9 billion, \nemsetting{network}{importanceGrouping} equal to 359 blocks and \nemsetting{minHarvesterBalance} equal to 10000 currency.
 Additionally, \nemsetting{network}{importanceActivityPercentage} is 5, so the cumulative transaction score accounts for 4\% of importance.
 
@@ -412,7 +412,7 @@ As more accounts attempt it, the importance boost obtained by each individual ac
 }.
 
 Additionally, there is an upper limit on the number of small accounts that can execute this attack simultaneously.
-In order for this attack to be successful, an account needs to be able to to harvest at least one block per importance recalculation interval.
+In order for this attack to be successful, an account needs to be able to harvest at least one block per importance recalculation interval.
 This presupposes the small account can boost its importance score by exploiting the transaction score component.
 There is a theoretical limit on the number of accounts that can achieve a significant enough boost because both the importance allotted to the transaction score and the recalculation interval are finite.
 Considering the recommended public network settings, this limit is approximately $0.04 \div \frac{1}{359} \approx 14.36$ accounts.

--- a/whitepaper/chapters/consensus.tex
+++ b/whitepaper/chapters/consensus.tex
@@ -94,7 +94,7 @@ T_A = \frac{\mathfunc{FeesPaid}(A)}{\sum\limits_{\substack{a \in \mathname{high 
 \end{equation}
 
 The node score, $N_A$, for an account $A$ is the percentage of times it has been specified as a beneficiary relative to the total number of high value account beneficiaries within a time period $P$.
-Let $\mathfunc{BeneficiaryCount}{A}$represent the number of times $A$ has been specified as a beneficiary in the time period $P$.
+Let $\mathfunc{BeneficiaryCount}{A}$ represent the number of times $A$ has been specified as a beneficiary in the time period $P$.
 The node score for account $A$ is calculated for each eligible account as follows:
 
 \begin{equation}


### PR DESCRIPTION
- [ ] “PoS that borrows key concepts from Proof of Importance (PoI).”
POI has not been explained at this point. Needs short explanation or something to assure the reader they didn’t somehow miss it previously.
- [ ]  “cumulative transaction score accounts for 4% of importance” It would be nice to link/reference the relevant calculation so I can go back and look at where the 4% came from.