### PR TITLE
Update cryptography.tex

### DIFF
--- a/whitepaper/chapters/cryptography.tex
+++ b/whitepaper/chapters/cryptography.tex
@@ -40,7 +40,7 @@ S &= (r + \hf(\underline{R}, \underline{A}, M)a) \: mod \: q \label{eq:cryptogra
 \end{align}
 
 Then $(\underline{R}, \underline{S})$ is the \nind{signature} for the message $M$ under the private key $k$.
-Note that only signatures where $S<q$ and $S>0$ are considered as valid \textbf{to prevent} the problem of \emph{signature malleability}\index{signature!malleability}.
+Only signatures where $S<q$ and $S>0$ are considered valid in order \textbf{to prevent} the problem of \emph{signature malleability}\index{signature!malleability}.
 
 To verify the signature $(\underline{R}, \underline{S})$ for the given message $M$ and public key \underline{A}, the verifier checks $S<q$ and $S>0$ and then calculates
 \begin{align*}


### PR DESCRIPTION
Reported by @matthewkim93

Other issues:
- [ ] “The specific curve being used is the Twisted Edwards curve: EQUATION  over the finite field defined by the prime number 2255 − 19 together with the digital signature algorithm called Ed25519.”
I don’t think this section is completely clear. Is it saying that Twisted Edwards Curve is everything after the colon? Or is it saying that the “specific curve” is the whole thing including the Twisted Edwards Curve?