### PR TITLE
Update the citation URL; remove legacy NEM domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you use Symbol whitepaper in your work, please cite:
   Howpublished         = {Web document},
   Month                = jan,
   Year                 = "2020",
-  URL                  = {https://nemtech.github.io/catapult-whitepaper/main.pdf}
+  URL                  = {https://symbol.github.io/symbol-technicalref/main.pdf}
 }
 ```
 


### PR DESCRIPTION
Replace the depreciated 'nemtech' url to the newer 'symbol' url in the Citation instructions